### PR TITLE
Make alive health check endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ This library combines [kafka-node](https://github.com/SOHU-Co/kafka-node) and [a
 * - * `version` : Version of the Schema
 * - * `key_fields` : Array of fields to use to build topic key.
 
+* `alive`	: Object representing Registry.alive settings
+* * `endpoint` : Health check endpoint
+
 See [sample options](https://github.com/narcisoguillen/kafka-node-avro/wiki/Sample-Options).
 
 # API

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports.init = async function(settings){
   core.Settings.read(settings);
   core.Registry.init();
 
-  let alive    = await core.Registry.alive();
+  let alive    = await core.Registry.alive(settings.alive);
   let client   = await core.Client.connect();
   let producer = await core.Producer.connect(client);
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,7 +1,7 @@
 const request  = require('request');
 const Settings = require('./settings');
 
-let Registry = {};
+const Registry = {};
 
 Registry.init = function(){
   Registry.host    = Settings.schema.registry;
@@ -17,11 +17,15 @@ Registry.GET = function(endpoint, callback){
 };
 
 // Health check endpoint
-Registry.alive = function(){
+Registry.alive = function(settings){
+  const endpoint = settings && 'endpoint' in settings
+    ? settings.endpoint
+    : 'subjects';
+    
   return new Promise(function(resolve, reject){
-    Registry.GET('subjects', (error, response, body) => {
+    Registry.GET(endpoint, (error, response, body) => {
       // failed
-      if(error || response.statusCode >= 400){ return reject(`Unabel Access Registry ${Registry.host}`); }
+      if(error || response.statusCode >= 400){ return reject(`Unable to access registry ${Registry.host}`); }
       return resolve(body);
     });
   });
@@ -31,7 +35,7 @@ Registry.fetchVersions = function(topicName){
   return new Promise( (resolve, reject) => {
     Registry.GET(`subjects/${topicName}-value/versions`, (error, response, body) => {
       // failed
-      if(error || response.statusCode >= 400){ return reject(`Unabel to load Schema ${topicName} Versions`); } // Failed
+      if(error || response.statusCode >= 400){ return reject(`Unable to load schema ${topicName} versions`); } // Failed
       return resolve(JSON.parse(body));
     });
   });
@@ -41,7 +45,7 @@ Registry.fetchByVersion = function(topicName, version){
   return new Promise( (resolve, reject) => {
     Registry.GET(`subjects/${topicName}-value/versions/${version}`, (error, response, body) => {
       // failed
-      if(error || response.statusCode >= 400){ return reject(`Unabel to load Schema ${topicName} Version : ${version}`); }
+      if(error || response.statusCode >= 400){ return reject(`Unable to load schema ${topicName} version : ${version}`); }
       return resolve(JSON.parse(body));
     });
   });
@@ -51,7 +55,7 @@ Registry.fetchById = function(id){
   return new Promise( (resolve, reject) => {
     Registry.GET(`schemas/ids/${id}`, (error, response, body) => {
       // failed
-      if(error || response.statusCode >= 400){ return reject(`Unabel to load Schema ${id}`); }
+      if(error || response.statusCode >= 400){ return reject(`Unable to load schema ${id}`); }
       return resolve(JSON.parse(body));
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-node-avro",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "kafka avro serialization",
   "main": "index.js",
   "author": "narciso guillen",

--- a/test/lib/registry.test.js
+++ b/test/lib/registry.test.js
@@ -40,6 +40,30 @@ describe('Registry', function() {
           return done();
         }, done);
       });
+
+      describe('with endpoint setting supplied', function() {
+        it('should touch registry to see if its alive', function(done) {
+          nock('http://test.registry.com').get('/foo').reply(200, ['test.topic']);
+
+          const settings = {endpoint: 'foo'};
+          Registry.alive(settings).then( alive => {
+            expect(alive).to.eql('["test.topic"]');
+            return done();
+          }, done);
+        });
+      });
+
+      describe('with empty endpoint setting supplied', function() {
+        it('should touch registry to see if its alive', function(done) {
+          nock('http://test.registry.com').get('/').reply(200, ['test.topic']);
+
+          const settings = {endpoint: ''};
+          Registry.alive(settings).then( alive => {
+            expect(alive).to.eql('["test.topic"]');
+            return done();
+          }, done);
+        });
+      });
     });
 
     describe('fetchVersions', function() {


### PR DESCRIPTION
This PR adds support to configure the alive health check endpoint.

Reason:
Not all Kafka setups support `/subjects` to be accessible but use another endpoint instead.