### PR TITLE
Allow user defined timestamp inside message

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -17,6 +17,7 @@ module.exports = class Shema {
         return resolve([{
           topic    : this.name,
           key      : data.key || this.genKey(data.messages),
+          timestamp : data.timestamp ? data.timestamp : undefined,
           messages : encoded
         }]);
       }, reject);

--- a/test/lib/schema.test.js
+++ b/test/lib/schema.test.js
@@ -78,6 +78,25 @@ describe('Shema', function() {
       } , done);
     });
 
+    it('should parse optional timestamp', function(done) {
+      let payload = {
+        timestamp: 1578400460000,
+        messages : {
+          foo : 'hello',
+          bar : 'world'
+        }
+      };
+
+      expect(this.schema.parse).to.be.a('function');
+      this.schema.parse(payload).then( parsed => {
+        expect(parsed).to.be.an('array');
+        expect(parsed[0].topic).to.eql('test.topic');
+        expect(parsed[0].key).to.eql('hello/world');
+        expect(parsed[0].timestamp).to.eql(1578400460000);
+        expect(Buffer.isBuffer(parsed[0].messages)).to.be(true);
+        return done();
+      } , done);
+    });
   });
 
   describe('genKey', function() {


### PR DESCRIPTION
From the documentation of the send method parameters:
```
timestamp : Date.now() // <-- defaults to Date.now() (only available with kafka v0.10 and KafkaClient only)
```

send method should be allowed to take timestamp as the parameter. For now, it was ignored.
