### PR TITLE
Add support for confluent cloud schema registry

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -10,13 +10,23 @@ const Registry = {
   }
 };
 
-Registry.init = function(){
-  Registry.host    = Settings.schema.registry;
-  Registry.request = request.defaults({
+Registry.init = function () {
+  Registry.host = Settings.schema.registry;
+  const opts = {
     headers: {
-      'Content-Type' : 'application/vnd.schemaregistry.v1+json'
+      'Content-Type': 'application/vnd.schemaregistry.v1+json'
     }
-  });
+  };
+
+  if (Settings.schema.key && Settings.schema.secret) {
+    opts.auth = {
+      user: Settings.schema.key,
+      pass: Settings.schema.secret,
+      sendImmediately: true
+    }
+  }
+
+  Registry.request = request.defaults(opts);
 
   Registry.buildEndpoints();
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -21,6 +21,8 @@ Settings.read = function(settings){
 
   Settings.kafka = settings.kafka;
   Settings.schema.registry = settings.schema.registry;
+  Settings.schema.key = settings.schema.key;
+  Settings.schema.secret = settings.schema.secret;
 
   if(settings.schema.topics){
     Settings.schema.topics = settings.schema.topics;


### PR DESCRIPTION
We want to use your lib with confluent cloud schema registry but need to have basic auth support.